### PR TITLE
✨ feat: add default WebhookSettings in Xero route handler

### DIFF
--- a/data-ingestion/di-webhook/src/webhook/lambda_function.py
+++ b/data-ingestion/di-webhook/src/webhook/lambda_function.py
@@ -13,6 +13,7 @@ settings = WebhookSettings()
 
 log_event: bool = settings.lambda_run_id != ""
 
+
 # Add routes here
 app.include_router(XeroRouter, prefix="xero")
 

--- a/data-ingestion/di-webhook/src/webhook/routes/xero.py
+++ b/data-ingestion/di-webhook/src/webhook/routes/xero.py
@@ -81,7 +81,7 @@ def process_xero_webhook():
         - 401 Unauthorized for incorrectly signed payloads
     """
     # Get the Lambda event and context from the decorator
-    api_settings: WebhookSettings = router.context.get("api_settings", None)
+    api_settings: WebhookSettings = router.context.get("api_settings", WebhookSettings())
     event = router.current_event
 
     # Get headers and body


### PR DESCRIPTION
# Pull Request Description

## Overview
This pull request introduces a new feature that adds default `WebhookSettings` in the Xero route handler. This enhancement is necessary to streamline the configuration process for users integrating with Xero, ensuring that they have a consistent and reliable setup out of the box.

## Type of Change
- [x] feat: New feature

## Changes Description

### Features
- Added default `WebhookSettings` in the Xero route handler to simplify user configuration.

### Fixes
- None

### Other Changes
- None

## Impact
These changes will improve the user experience by providing default settings, reducing the need for manual configuration and potential errors during setup.

## Testing Completed
- [x] Unit tests
- [ ] Integration tests
- [ ] Data validation tests
- [ ] Manual testing

## Data Changes
- [ ] Changes affect data schemas
- [ ] Changes affect data pipelines
- [ ] Changes affect data warehouse models
- [ ] Data quality checks implemented/updated

## Documentation
- [ ] Updated documentation for affected components
- [ ] Added/updated docstrings
- [ ] Added/updated comments for complex code sections

## Dependencies
- None

## Pre-Deployment Steps
- None

## Post-Deployment Verification
To verify the changes, ensure that the default `WebhookSettings` are correctly applied when the Xero route handler is initialized.

## Related Issues
Closes #

## Breaking Changes
- None

## Additional Notes
Reviewers should note that this feature is designed to enhance the integration process with Xero and should be tested in various scenarios to ensure compatibility.